### PR TITLE
Fix custom Git ignore list entries not applied

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -111,6 +111,14 @@
   tags: [ 'role::etckeeper:vcs_config' ]
 ## ]]]
 
+- name: Unstage ignored files from Git index
+  shell: etckeeper vcs ls-files -i --exclude-standard -z | xargs -0 etckeeper vcs reset --mixed --
+  register: git_reset
+  when:
+    - etckeeper__vcs == "git"
+    - etckeeper__register_init|changed
+  changed_when: git_reset.stdout
+
 - name: Create root commit
   command: etckeeper commit 'Initial commit created by Ansible.'
   when: etckeeper__register_init|changed


### PR DESCRIPTION
Hello,

This role adds custom entries to /etc/.gitignore after invoking
`etckeeper init`.

However, at that moment all files are already added to Git index, so we
need to remove them again before calling `etckeeper commit`. Otherwise
custom ignore list has no effect.

See `/etc/etckeeper/init.d/70vcs-add`